### PR TITLE
Use more restrictive regex for stable names

### DIFF
--- a/wg21link.js
+++ b/wg21link.js
@@ -59,7 +59,7 @@ function replacePapers() {
 }
 
 function replaceStableNames() {
-  var re = /\[([a-zA-Z\.0-9]+)\]/g;
+  var re = /\[([a-zA-Z][a-zA-Z\.0-9]+)\]/g;
   var regs;
 
   var walker = document.createTreeWalker(


### PR DESCRIPTION
There are no stable names that begin with a dot or a digit. This avoids turning text like "[1]" into a (broken) link to the draft.

There are currently no stable names that contain uppercase letters either, but I've not encountered unwanted links caused by that, unlike the "[1]" case.